### PR TITLE
[FEAT] Ajout d'un nouveau modèle pour la configuration des opérations

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -25,8 +25,10 @@
 
     # always loaded
     'data': [
+        'security/ir.model.access.csv',
         'views/views.xml',
         'views/stock_move_view.xml',
-        'views/mrp_menu.xml'
+        'views/mrp_menu.xml',
+        'views/mrp_routing_workcenter.xml'
     ],
 }

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import mrp
+from . import mrp_routing_workcenter

--- a/models/mrp_routing_workcenter.py
+++ b/models/mrp_routing_workcenter.py
@@ -1,0 +1,59 @@
+from odoo import api, fields,models
+
+class MrpRoutingWorkcenter(models.Model):
+    _inherit = "mrp.routing.workcenter"
+
+    allowed_bom_ids = fields.One2many('mrp.routing.bom', 'route_workcenter_id', string="Allowed nomenclature")
+    taken_boom_ids = fields.Many2many('mrp.bom', compute="_compute_taken_bom_ids")
+    
+    @api.depends('allowed_bom_ids.bom_id')
+    def _compute_taken_bom_ids(self):
+        for rec in self:
+            rec.taken_boom_ids = (rec.allowed_bom_ids.mapped('bom_id') + rec.bom_id).ids
+
+class MrpBom(models.Model):
+    _inherit ="mrp.bom"
+
+    operation_ids = fields.Many2many('mrp.routing.workcenter', 'bom_id', string='Operations', copy=True)
+    allowed_operation_ids = fields.Many2many('mrp.routing.workcenter', compute="_compute_allowed_operations")
+
+    
+    def _compute_allowed_operations(self):
+        routing_bom = self.env['mrp.routing.bom']
+        workcenter = self.env['mrp.routing.workcenter']
+
+        for rec in self:
+            workcenter_id_via_config = routing_bom.search([('bom_id', '=', rec.id)]).route_workcenter_id
+            workcenter_id = workcenter.search([('bom_id', '=', rec.id)])
+            rec.allowed_operation_ids = (workcenter_id_via_config + workcenter_id).mapped('id')
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    allowed_operation_ids = fields.Many2many(
+        'mrp.routing.workcenter', related='raw_material_production_id.bom_id.operation_ids')
+    
+class MrpBomLine(models.Model):
+    _inherit = "mrp.bom.line"
+
+    allowed_operation_ids = fields.Many2many('mrp.routing.workcenter', related='bom_id.operation_ids')
+
+class MrpBomByProduct(models.Model):
+    _inherit = "mrp.bom.byproduct"
+
+    allowed_operation_ids = fields.Many2many('mrp.routing.workcenter', related='bom_id.operation_ids')
+
+class MrpRoutingBom(models.Model):
+    _name = "mrp.routing.bom"
+
+    route_workcenter_id = fields.Many2one("mrp.routing.workcenter", string="Opération")
+    bom_id = fields.Many2one("mrp.bom", string="Nomenclature")
+    workcenter_id = fields.Many2one('mrp.workcenter', string="Poste de travail", default=lambda self: self.route_workcenter_id.workcenter_id.id)
+    taken_boom_ids = fields.Many2many(related='route_workcenter_id.taken_boom_ids')
+
+
+
+
+
+
+

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mr_routing_bom,mrp_routing_bom,model_mrp_routing_bom,base.group_user,1,1,1,1

--- a/views/mrp_routing_workcenter.xml
+++ b/views/mrp_routing_workcenter.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mrp_routing_workcenter_inherit_sos_mrp" model="ir.ui.view">
+        <field name="name">Mpr routing workcenter</field>
+        <field name="model">mrp.routing.workcenter</field>
+        <field name="inherit_id" ref="mrp.mrp_routing_workcenter_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Configuration" name="configuration">
+                    <field name="taken_boom_ids" invisible="1"/>
+                    <field name="allowed_bom_ids" widget="one2many">
+                        <tree editable="bottom" create='1' no_open="1">
+                            <field name="taken_boom_ids" invisible="1"/>
+                            <field name="bom_id" domain="[('id', 'not in', taken_boom_ids)]"/>
+                            <field name="workcenter_id" />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+    <record id="mrp_bom_view__inherit_sos_mrp_base" model="ir.ui.view">
+        <field name="name">Inherit MRP BOM</field>
+        <field name="model">mrp.bom</field>
+        <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_tmpl_id']" position="after">
+                <field name="allowed_operation_ids" invisible="1"/>
+                
+            </xpath>
+            <xpath expr="//field[@name='operation_ids']" position="attributes">
+                <attribute name="domain">[('id', 'in', allowed_operation_ids)]</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Ajout d'un nouveau modèle pour permettre l'utilisation des opérations sur plusieurs nomenclatures (BOM). 

**Cette modification est nécessaire car l'ancienne relation one2many entre les opérations et les nomenclatures doit être changée en many2many pour permettre leur utilisation sur différentes nomenclatures.** 

**### Cela peut être risqué s'il y a beaucoup d'opérations dans Odoo.**